### PR TITLE
feat: GitHubの認証チェックはサーバー側で行うためクライアント側は不要

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -13,15 +13,14 @@ import { CopyToClipboardButton } from './_features/CopyToClipboardButton'
 import { showList } from './showList'
 
 interface SubmitButtonProps {
-  isLoading: boolean
   isDisabled: boolean
 }
 
-const SubmitButton: FC<SubmitButtonProps> = ({ isLoading, isDisabled }) => {
+const SubmitButton: FC<SubmitButtonProps> = ({ isDisabled }) => {
   const { pending } = useFormStatus()
 
   return (
-    <Button isLoading={isLoading || pending} type="submit" isDisabled={isDisabled}>
+    <Button isLoading={pending} type="submit" isDisabled={isDisabled}>
       Run
     </Button>
   )
@@ -29,7 +28,6 @@ const SubmitButton: FC<SubmitButtonProps> = ({ isLoading, isDisabled }) => {
 
 function Home() {
   const { status, data } = useSession()
-  const isLoading = status === 'loading'
   const isUnAuthenticated = status === 'unauthenticated'
   const [state, formAction] = useFormState(showList, {
     success: true,
@@ -47,7 +45,7 @@ function Home() {
             <GistIdInput />
           </details>
           <div>
-            <SubmitButton isLoading={isLoading} isDisabled={isUnAuthenticated} />
+            <SubmitButton isDisabled={isUnAuthenticated} />
           </div>
         </form>
         <div>


### PR DESCRIPTION
これにより認証チェックの時間が短縮でき、またJSを無効化にしている状況でもフォーム送信が可能となる